### PR TITLE
Attempt to fix the current issue with libzippp on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,12 @@ FetchContent_Declare(spdlog
         GIT_TAG v1.13.0)
 FetchContent_MakeAvailable(spdlog)
 
+FetchContent_Declare(libzip
+        GIT_REPOSITORY https://github.com/nih-at/libzip
+        GIT_TAG v1.10.1
+        OVERRIDE_FIND_PACKAGE)
+FetchContent_MakeAvailable(libzip)
+
 FetchContent_Declare(libzippp
         GIT_REPOSITORY https://github.com/ctabin/libzippp
         GIT_TAG libzippp-v7.1-1.10.1)


### PR DESCRIPTION
The main issue is that `libzippp` invokes `FindLIBZIP.cmake` which is supposed to make sure we've got `libzip` (it's dependency of `libzippp`) installed. Unfortunately, the library doesn't do anything if the dependency is not present => it's our job to install `libzip`.
The previous attempts to bring `libzip` to V4Hero have likely failed because of the way the checks are performed:
```cmake
find_package(ZLIB REQUIRED)

find_path(LIBZIP_INCLUDE_DIR NAMES zip.h)
mark_as_advanced(LIBZIP_INCLUDE_DIR)

find_library(LIBZIP_LIBRARY NAMES zip)
mark_as_advanced(LIBZIP_LIBRARY)

get_filename_component(_libzip_libdir ${LIBZIP_LIBRARY} DIRECTORY)
find_file(_libzip_pkgcfg libzip.pc
    HINTS ${_libzip_libdir} ${LIBZIP_INCLUDE_DIR}/..
    PATH_SUFFIXES pkgconfig lib/pkgconfig libdata/pkgconfig
    NO_DEFAULT_PATH
)

include(FindPackageHandleStandardArgs)
find_package_handle_standard_args(
    LIBZIP
    REQUIRED_VARS
        LIBZIP_LIBRARY
        LIBZIP_INCLUDE_DIR
        _libzip_pkgcfg
)
```

There's nothing wrong with the first line, but the other checks all fail because `FetchContent` puts the downloaded files into `{build_dir}/_deps`, but the `find_{...}` commands don't consider this path while looking for the arguments.
It seems that slapping this `OVERRIDE_FIND_PACKAGE` into `FetchContent_Declare` exposes the downloaded files to these commands.

(Found out about that [here](https://stackoverflow.com/questions/73621403/cmake-integrating-fetchcontent-with-find-package))